### PR TITLE
fix: scan tripcut controllers for global exception handling

### DIFF
--- a/src/main/java/com/tripcut/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/tripcut/global/common/exception/GlobalExceptionHandler.java
@@ -12,7 +12,7 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 
 @Slf4j
 // 모든 rest컨트롤러에서 발생하는 예외 처리
-@RestControllerAdvice(basePackages = "com.moyang")
+@RestControllerAdvice(basePackages = "com.tripcut")
 public class GlobalExceptionHandler {
 
     // 지원되지 않는 HTTP 메소드를 사용할 때 발생하는 예외


### PR DESCRIPTION
## Summary
- update RestControllerAdvice to scan `com.tripcut`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68be5f34dfec8332a598e10ab1751d2f